### PR TITLE
skip empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,8 @@ task(TASK_COMPILE, async function (args, hre, runSuper) {
     try {
       let { abi } = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
 
+      if (!abi.length) continue;
+
       let destination;
 
       if (config.flat) {


### PR DESCRIPTION
skip empty abis.
for example, dYdX protocol has a lot of interfaces with types only (enums and structs):

```solidity
interface IAccount {
  enum Status { Normal, Liquid, Vapor }

  struct Info {
    address owner;
    uint256 number;
  }

  struct Storage {
    mapping (uint256 => ITypes.Par) balances;
    Status status;
  }
}

interface ITypes {
  enum AssetDenomination { Wei, Par }

  enum AssetReference { Delta, Target }

  struct AssetAmount {
    bool sign;
    AssetDenomination denomination;
    AssetReference ref;
    uint256 value;
  }

  struct TotalPar {
    uint128 borrow;
    uint128 supply;
  }

  struct Par {
    bool sign;
    uint128 value;
  }

  struct Wei {
    bool sign;
    uint256 value;
  }
}
```