### PR TITLE
Allow external dir and multiple file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,19 @@ Add configuration under the `abiExporter` key:
 
 | option | description | default |
 |-|-|-|
-| `path` | path to ABI export directory (relative to Hardhat root) | `'./abi'`
+| `path` | path(s) to ABI export directory (relative to Hardhat root or external dir if `allowExternalDir` is true) | `'./abi'` or `['./abi', './abi2']`
 | `clear` | whether to delete old files in `path` on  | `false` |
 | `flat` | whether to flatten output directory (may cause name collisions) | `false` |
 | `only` | `Array` of contracts to include (case sensitive), defaults to all contracts if `length` is 0 | `[]` |
 | `except` | `Array` of contracts to exclude (case sensitive) | `[]` |
+| `allowExternalDir` | whether to allow writing to dirs outside of working dir | `false` |
 
 ```javascript
 abiExporter: {
-  path: './data/abi',
+  path: './data/abi', // or ['./data/abi', './data2/abi2']
   clear: true,
   flat: true,
+  allowExternalDir: true,
   only: ['ERC20'],
 }
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add configuration under the `abiExporter` key:
 
 | option | description | default |
 |-|-|-|
-| `path` | path(s) to ABI export directory (relative to Hardhat root or external dir if `allowExternalDir` is true) | `'./abi'` or `['./abi', './abi2']`
+| `path` | `string` path or `Array` of paths to ABI export directory (relative to Hardhat root or external dir if `allowExternalDir` is true) | `'./abi'`
 | `clear` | whether to delete old files in `path` on  | `false` |
 | `flat` | whether to flatten output directory (may cause name collisions) | `false` |
 | `only` | `Array` of contracts to include (case sensitive), defaults to all contracts if `length` is 0 | `[]` |

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ declare module 'hardhat/types/config' {
       clear?: boolean,
       flat?: boolean,
       only?: string[],
+      allowExternalDir?: boolean,
       except?: string[],
     }
   }
@@ -15,6 +16,7 @@ declare module 'hardhat/types/config' {
     abiExporter: {
       path: string,
       clear: boolean,
+      allowExternalDir: boolean,
       flat: boolean,
       only: string[],
       except: string[],

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import 'hardhat/types/config';
 declare module 'hardhat/types/config' {
   interface HardhatUserConfig {
     abiExporter?: {
-      path?: string,
+      path?: string | string[],
       clear?: boolean,
       flat?: boolean,
       only?: string[],
@@ -14,7 +14,7 @@ declare module 'hardhat/types/config' {
 
   interface HardhatConfig {
     abiExporter: {
-      path: string,
+      path: string | string[],
       clear: boolean,
       allowExternalDir: boolean,
       flat: boolean,

--- a/index.js
+++ b/index.js
@@ -21,70 +21,70 @@ extendConfig(function (config, userConfig) {
 });
 
 task(TASK_COMPILE, async function (args, hre, runSuper) {
-    let config = hre.config.abiExporter;
+  let config = hre.config.abiExporter;
 
-    await runSuper();
+  await runSuper();
 
-    const paths = Array.isArray(config.path) ? config.path : [config.path];
+  const paths = Array.isArray(config.path) ? config.path : [config.path];
 
-    for (_path of paths) {
-        let outputDirectory = config.allowExternalDir ? _path : path.resolve(hre.config.paths.root, _path);
+  for (_path of paths) {
+    let outputDirectory = config.allowExternalDir ? _path : path.resolve(hre.config.paths.root, _path);
 
-        if (!config.allowExternalDir && !outputDirectory.startsWith(hre.config.paths.root)) {
-            throw 'hardhat-abi-exporter: resolved path must be inside of project directory';
-        }
-
-        if(outputDirectory === hre.config.paths.root) {
-            throw 'hardhat-abi-exporter: resolved path must not be root directory';
-        }
-
-        if (config.clear) {
-            fs.rmdirSync(outputDirectory, { recursive: true });
-        }
-
-        if (!fs.existsSync(outputDirectory)) {
-            fs.mkdirSync(outputDirectory, { recursive: true });
-        }
-
-        let artifactPaths = await hre.artifacts.getArtifactPaths();
-
-        let nameOf = artifactPath => path.basename(artifactPath).replace('.json', '');
-
-        if (config.only.length) {
-            let only = new Set(config.only);
-            artifactPaths = artifactPaths.filter(artifactPath => only.has(nameOf(artifactPath)));
-        }
-
-        if (config.except.length) {
-            let except = new Set(config.except);
-            artifactPaths = artifactPaths.filter(artifactPath => !except.has(nameOf(artifactPath)));
-        }
-
-        for (let artifactPath of artifactPaths) {
-            try {
-                let { abi } = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
-
-                if (!abi.length) continue;
-
-                let destination;
-
-                if (config.flat) {
-                    destination = `${ nameOf(artifactPath) }.json`;
-                } else {
-                    destination = `${ artifactPath.replace(hre.config.paths.artifacts, '') }`;
-                }
-
-                destination = path.resolve(`${ outputDirectory }/${ destination }`);
-
-                if (!fs.existsSync(path.dirname(destination))) {
-                    fs.mkdirSync(path.dirname(destination), { recursive: true });
-                }
-
-                fs.writeFileSync(destination, `${ JSON.stringify(abi, null, 2) }\n`, { flag: 'w' });
-            } catch (e) {
-                console.log(`Artifact not found for contract: ${ nameOf(artifactPath) }`);
-            }
-        }
+    if (!config.allowExternalDir && !outputDirectory.startsWith(hre.config.paths.root)) {
+      throw 'hardhat-abi-exporter: resolved path must be inside of project directory';
     }
+
+    if(outputDirectory === hre.config.paths.root) {
+      throw 'hardhat-abi-exporter: resolved path must not be root directory';
+    }
+
+    if (config.clear) {
+      fs.rmdirSync(outputDirectory, { recursive: true });
+    }
+
+    if (!fs.existsSync(outputDirectory)) {
+      fs.mkdirSync(outputDirectory, { recursive: true });
+    }
+
+    let artifactPaths = await hre.artifacts.getArtifactPaths();
+
+    let nameOf = artifactPath => path.basename(artifactPath).replace('.json', '');
+
+    if (config.only.length) {
+        let only = new Set(config.only);
+        artifactPaths = artifactPaths.filter(artifactPath => only.has(nameOf(artifactPath)));
+    }
+
+    if (config.except.length) {
+        let except = new Set(config.except);
+        artifactPaths = artifactPaths.filter(artifactPath => !except.has(nameOf(artifactPath)));
+    }
+
+    for (let artifactPath of artifactPaths) {
+      try {
+        let { abi } = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
+
+        if (!abi.length) continue;
+
+        let destination;
+
+        if (config.flat) {
+          destination = `${ nameOf(artifactPath) }.json`;
+        } else {
+          destination = `${ artifactPath.replace(hre.config.paths.artifacts, '') }`;
+        }
+
+        destination = path.resolve(`${ outputDirectory }/${ destination }`);
+
+        if (!fs.existsSync(path.dirname(destination))) {
+          fs.mkdirSync(path.dirname(destination), { recursive: true });
+        }
+
+        fs.writeFileSync(destination, `${ JSON.stringify(abi, null, 2) }\n`, { flag: 'w' });
+      } catch (e) {
+        console.log(`Artifact not found for contract: ${ nameOf(artifactPath) }`);
+      }
+    }
+  }
 
 });

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ extendConfig(function (config, userConfig) {
       path: './abi',
       clear: false,
       flat: false,
+      allowExternalDir: false,
       only: [],
       except: [],
     },
@@ -20,65 +21,70 @@ extendConfig(function (config, userConfig) {
 });
 
 task(TASK_COMPILE, async function (args, hre, runSuper) {
-  let config = hre.config.abiExporter;
+    let config = hre.config.abiExporter;
 
-  await runSuper();
+    await runSuper();
 
-  let outputDirectory = path.resolve(hre.config.paths.root, config.path);
+    const paths = Array.isArray(config.path) ? config.path : [config.path];
 
-  if (!outputDirectory.startsWith(hre.config.paths.root)) {
-    throw 'hardhat-abi-exporter: resolved path must be inside of project directory';
-  }
+    for (_path of paths) {
+        let outputDirectory = config.allowExternalDir ? _path : path.resolve(hre.config.paths.root, _path);
 
-  if(outputDirectory === hre.config.paths.root) {
-    throw 'hardhat-abi-exporter: resolved path must not be root directory';
-  }
+        if (!config.allowExternalDir && !outputDirectory.startsWith(hre.config.paths.root)) {
+            throw 'hardhat-abi-exporter: resolved path must be inside of project directory';
+        }
 
-  if (config.clear) {
-    fs.rmdirSync(outputDirectory, { recursive: true });
-  }
+        if(outputDirectory === hre.config.paths.root) {
+            throw 'hardhat-abi-exporter: resolved path must not be root directory';
+        }
 
-  if (!fs.existsSync(outputDirectory)) {
-    fs.mkdirSync(outputDirectory, { recursive: true });
-  }
+        if (config.clear) {
+            fs.rmdirSync(outputDirectory, { recursive: true });
+        }
 
-  let artifactPaths = await hre.artifacts.getArtifactPaths();
+        if (!fs.existsSync(outputDirectory)) {
+            fs.mkdirSync(outputDirectory, { recursive: true });
+        }
 
-  let nameOf = artifactPath => path.basename(artifactPath).replace('.json', '');
+        let artifactPaths = await hre.artifacts.getArtifactPaths();
 
-  if (config.only.length) {
-    let only = new Set(config.only);
-    artifactPaths = artifactPaths.filter(artifactPath => only.has(nameOf(artifactPath)));
-  }
+        let nameOf = artifactPath => path.basename(artifactPath).replace('.json', '');
 
-  if (config.except.length) {
-    let except = new Set(config.except);
-    artifactPaths = artifactPaths.filter(artifactPath => !except.has(nameOf(artifactPath)));
-  }
+        if (config.only.length) {
+            let only = new Set(config.only);
+            artifactPaths = artifactPaths.filter(artifactPath => only.has(nameOf(artifactPath)));
+        }
 
-  for (let artifactPath of artifactPaths) {
-    try {
-      let { abi } = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
+        if (config.except.length) {
+            let except = new Set(config.except);
+            artifactPaths = artifactPaths.filter(artifactPath => !except.has(nameOf(artifactPath)));
+        }
 
-      if (!abi.length) continue;
+        for (let artifactPath of artifactPaths) {
+            try {
+                let { abi } = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
 
-      let destination;
+                if (!abi.length) continue;
 
-      if (config.flat) {
-        destination = `${ nameOf(artifactPath) }.json`;
-      } else {
-        destination = `${ artifactPath.replace(hre.config.paths.artifacts, '') }`;
-      }
+                let destination;
 
-      destination = path.resolve(`${ outputDirectory }/${ destination }`);
+                if (config.flat) {
+                    destination = `${ nameOf(artifactPath) }.json`;
+                } else {
+                    destination = `${ artifactPath.replace(hre.config.paths.artifacts, '') }`;
+                }
 
-      if (!fs.existsSync(path.dirname(destination))) {
-        fs.mkdirSync(path.dirname(destination), { recursive: true });
-      }
+                destination = path.resolve(`${ outputDirectory }/${ destination }`);
 
-      fs.writeFileSync(destination, `${ JSON.stringify(abi, null, 2) }\n`, { flag: 'w' });
-    } catch (e) {
-      console.log(`Artifact not found for contract: ${ nameOf(artifactPath) }`);
+                if (!fs.existsSync(path.dirname(destination))) {
+                    fs.mkdirSync(path.dirname(destination), { recursive: true });
+                }
+
+                fs.writeFileSync(destination, `${ JSON.stringify(abi, null, 2) }\n`, { flag: 'w' });
+            } catch (e) {
+                console.log(`Artifact not found for contract: ${ nameOf(artifactPath) }`);
+            }
+        }
     }
-  }
+
 });

--- a/index.js
+++ b/index.js
@@ -51,13 +51,13 @@ task(TASK_COMPILE, async function (args, hre, runSuper) {
     let nameOf = artifactPath => path.basename(artifactPath).replace('.json', '');
 
     if (config.only.length) {
-        let only = new Set(config.only);
-        artifactPaths = artifactPaths.filter(artifactPath => only.has(nameOf(artifactPath)));
+      let only = new Set(config.only);
+      artifactPaths = artifactPaths.filter(artifactPath => only.has(nameOf(artifactPath)));
     }
 
     if (config.except.length) {
-        let except = new Set(config.except);
-        artifactPaths = artifactPaths.filter(artifactPath => !except.has(nameOf(artifactPath)));
+      let except = new Set(config.except);
+      artifactPaths = artifactPaths.filter(artifactPath => !except.has(nameOf(artifactPath)));
     }
 
     for (let artifactPath of artifactPaths) {


### PR DESCRIPTION
Allows a user to specify multiple file paths to write to and also an option to enable writing to paths outside of the current hardhat directory - by default this is set to `false`.