### PR TITLE
Fix error on Node 16 if ABI dir doesn't exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ task(TASK_COMPILE, async function (args, hre, runSuper) {
   }
 
   if (config.clear) {
-    fs.rmdirSync(outputDirectory, { recursive: true });
+    if (fs.existsSync(outputDirectory)) {
+      fs.rmdirSync(outputDirectory, { recursive: true });
+    }
   }
 
   if (!fs.existsSync(outputDirectory)) {


### PR DESCRIPTION
## Description

Node.js 16 has been released: https://nodejs.medium.com/node-js-16-available-now-7f5099a97e70

I tried updating the newly-released Node 16, and discovered that a change in `fs.rmdirSync()` causes a failure when running `hardhat compile` in a fresh repo before the abi folder has been created. Apparently in Node 16, `fs.rmdirSync()` requires an existence check as it will no longer succeed when the directory doesn't exist.

## How has this been tested?

Before the PR, running `hardhat compile` gives the following error:

```
An unexpected error occurred:
Error: ENOENT: no such file or directory, stat './abi'
```

After this PR, `hardhat compile` succeeds.