### PR TITLE
Removes path inside of project dir requirement

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,10 +72,6 @@ task(TASK_COMPILE, async function (args, hre, runSuper) {
 
   const outputDirectory = path.resolve(hre.config.paths.root, config.path);
 
-  if (!outputDirectory.startsWith(hre.config.paths.root)) {
-    throw new HardhatPluginError('resolved path must be inside of project directory');
-  }
-
   if (outputDirectory === hre.config.paths.root) {
     throw new HardhatPluginError('resolved path must not be root directory');
   }


### PR DESCRIPTION
This pull request removes the requirement that a given `path` value exist inside of the Hardhat project's directory.  Currently the package is a non-starter for multi-module directory structures, such as:

```
- /modules
- - /contracts
- - /web
- - - /abis
```

where `/modules/contracts` is the project's root but `/modules/web/abis` is the target directory.

Looking at the [Git blame](https://github.com/ItsNickBarry/hardhat-abi-exporter/commit/67d7a8f23c96640c58083a00179cca7a30dab7a3), it appears this check exists to project the user from inadvertently overwriting a directory.  I believe that the library should not impose an opinion overriding the user's preference, and should respect their usage of the `clear` parameter (which responsibly defaults to `false`).