### PR TITLE
feat: Make some filesystem access async

### DIFF
--- a/tasks/export_abi.js
+++ b/tasks/export_abi.js
@@ -31,13 +31,13 @@ task('export-abi', async function (args, hre) {
     ) + '.json';
 
     if (!fs.existsSync(path.dirname(destination))) {
-      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      await fs.promises.mkdir(path.dirname(destination), { recursive: true });
     }
 
     if (config.pretty) {
       abi = new Interface(abi).format(FormatTypes.minimal);
     }
 
-    fs.writeFileSync(destination, `${JSON.stringify(abi, null, config.spacing)}\n`, { flag: 'w' });
+    await fs.promises.writeFile(destination, `${JSON.stringify(abi, null, config.spacing)}\n`, { flag: 'w' });
   }
 });

--- a/tasks/export_abi.js
+++ b/tasks/export_abi.js
@@ -36,9 +36,7 @@ task('export-abi', async function (args, hre) {
       contractName
     ) + '.json';
 
-    if (!fs.existsSync(path.dirname(destination))) {
-      await fs.promises.mkdir(path.dirname(destination), { recursive: true });
-    }
+    await fs.promises.mkdir(path.dirname(destination), { recursive: true });
 
     await fs.promises.writeFile(destination, `${JSON.stringify(abi, null, config.spacing)}\n`, { flag: 'w' });
   }));

--- a/tasks/export_abi.js
+++ b/tasks/export_abi.js
@@ -24,6 +24,10 @@ task('export-abi', async function (args, hre) {
 
     if (!abi.length) continue;
 
+    if (config.pretty) {
+      abi = new Interface(abi).format(FormatTypes.minimal);
+    }
+
     const destination = path.resolve(
       outputDirectory,
       config.flat ? '' : sourceName,
@@ -32,10 +36,6 @@ task('export-abi', async function (args, hre) {
 
     if (!fs.existsSync(path.dirname(destination))) {
       await fs.promises.mkdir(path.dirname(destination), { recursive: true });
-    }
-
-    if (config.pretty) {
-      abi = new Interface(abi).format(FormatTypes.minimal);
     }
 
     await fs.promises.writeFile(destination, `${JSON.stringify(abi, null, config.spacing)}\n`, { flag: 'w' });


### PR DESCRIPTION
I converted a couple of the filesystem functions to use `await` and promises, where possible. The promise equivalent of `fs.existsSync` is to use `fs.promises.access`, but I didn't want to make that change because I think the `existsSync` isn't needed when using `{ recursive: true }` which will only fail if it encounters a file.