### PR TITLE
feat: Allow renaming exported ABIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add configuration under the `abiExporter` key:
 | `spacing` | number of spaces per indentation level of formatted output | `2` |
 | `pretty` | whether to use interface-style formatting of output for better readability | `false` |
 | `filter` | `Function` with signature `(abiElement: any, index: number, abi: any, fullyQualifiedName: string) => boolean` used to filter elements from each exported ABI | `() => true` |
-| `rename` | `Function` with signature `(sourceName: string, contractName: string) => string` used to rename an exported ABI | |
+| `rename` | `Function` with signature `(sourceName: string, contractName: string) => string` used to rename an exported ABI (incompatible with `flat` option) | `undefined` |
 
  Note that the configuration formatted as either a single `Object`, or an `Array` of objects.  An `Array` may be used to specify multiple outputs.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Add configuration under the `abiExporter` key:
 | `spacing` | number of spaces per indentation level of formatted output | `2` |
 | `pretty` | whether to use interface-style formatting of output for better readability | `false` |
 | `filter` | `Function` with signature `(abiElement: any, index: number, abi: any, fullyQualifiedName: string) => boolean` used to filter elements from each exported ABI | `() => true` |
+| `rename` | `Function` with signature `(sourceName: string, contractName: string) => string` used to rename an exported ABI | |
 
  Note that the configuration formatted as either a single `Object`, or an `Array` of objects.  An `Array` may be used to specify multiple outputs.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ interface AbiExporterUserConfig {
   spacing?: number,
   pretty?: boolean,
   filter?: (abiElement: any, index: number, abi: any, fullyQualifiedName: string) => boolean,
+  rename?: (sourceName: string, contractName: string) => string,
 }
 
 declare module 'hardhat/types/config' {
@@ -22,12 +23,12 @@ declare module 'hardhat/types/config' {
       path: string,
       runOnCompile: boolean,
       clear: boolean,
-      flat: boolean,
       only: string[],
       except: string[],
       spacing: number,
       pretty: boolean,
       filter: (abiElement: any, index: number, abi: any, fullyQualifiedName: string) => boolean,
+      rename: (sourceName: string, contractName: string) => string,
     }[]
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,7 @@ declare module 'hardhat/types/config' {
       path: string,
       runOnCompile: boolean,
       clear: boolean,
+      flat: boolean,
       only: string[],
       except: string[],
       spacing: number,

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ extendConfig(function (config, userConfig) {
     validate(conf, 'path', 'string');
     validate(conf, 'runOnCompile', 'boolean');
     validate(conf, 'clear', 'boolean');
+    validate(conf, 'flat', 'boolean');
     validate(conf, 'only', 'array');
     validate(conf, 'except', 'array');
     validate(conf, 'spacing', 'number');

--- a/index.js
+++ b/index.js
@@ -11,12 +11,13 @@ const DEFAULT_CONFIG = {
   path: './abi',
   runOnCompile: false,
   clear: false,
+  flat: false,
   only: [],
   except: [],
   spacing: 2,
   pretty: false,
   filter: () => true,
-  // `flat` and `rename` are not defaulted so they can be validated for mutual exclusion
+  // `rename` is not defaulted as it may depend on `flat` option
 };
 
 function validate(config, key, type) {

--- a/index.js
+++ b/index.js
@@ -43,18 +43,16 @@ extendConfig(function (config, userConfig) {
     validate(conf, 'pretty', 'boolean');
     validate(conf, 'filter', 'function');
 
-    if (typeof conf.flat !== 'undefined') {
-      validate(conf, 'flat', 'boolean');
+    if (conf.flat && typeof conf.rename !== 'undefined') {
+      throw new HardhatPluginError(PLUGIN_NAME, '`flat` & `rename` config cannot be specified together');
+    }
 
-      if (typeof conf.rename !== 'undefined') {
-        throw new HardhatPluginError(PLUGIN_NAME, '`flat` & `rename` config cannot be specified together');
-      }
+    if (conf.flat) {
+      conf.rename = (sourceName, contractName) => contractName;
+    }
 
-      if (conf.flat) {
-        conf.rename = (_sourceName, contractName) => contractName;
-      } else {
-        conf.rename = (sourceName, contractName) => path.join(sourceName, contractName);
-      }
+    if (!conf.rename) {
+      conf.rename = (sourceName, contractName) => path.join(sourceName, contractName);
     }
 
     validate(conf, 'rename', 'function');

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
+const path = require('path');
 const { extendConfig } = require('hardhat/config');
 const { HardhatPluginError } = require('hardhat/plugins');
-const { name: PLUGIN_NAME } = require('./package.json')
+const { name: PLUGIN_NAME } = require('./package.json');
 
 require('./tasks/clear_abi.js');
 require('./tasks/export_abi.js');
@@ -21,7 +22,7 @@ const DEFAULT_CONFIG = {
 function validate(config, key, type) {
   if (type === 'array') {
     if (!Array.isArray(config[key])) {
-      throw new HardhatPluginError(PLUGIN_NAME, `\`${key}\` config must be an ${type}`)
+      throw new HardhatPluginError(PLUGIN_NAME, `\`${key}\` config must be an ${type}`);
     }
   } else {
     if (typeof config[key] !== type) {

--- a/tasks/export_abi.js
+++ b/tasks/export_abi.js
@@ -56,8 +56,7 @@ subtask(
 
     const destination = path.resolve(
       outputDirectory,
-      config.flat ? '' : sourceName,
-      contractName
+      config.rename(sourceName, contractName)
     ) + '.json';
 
     outputData.push({ abi, destination });


### PR DESCRIPTION
This allows users to rename their exported ABIs without any additional task hooks or filesystem reads. They can specify a `rename` function that receives the fully qualified name and returns a new name.