### PR TITLE
Multi export

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
   ],
   'globals': {
     'task': 'readonly',
+    'subtask': 'readonly',
   },
   'parserOptions': {
     'ecmaVersion': 2018,

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Add configuration under the `abiExporter` key:
 | `pretty` | whether to use interface-style formatting of output for better readability | `false` |
 | `filter` | `Function` with signature `(abiElement: any, index: number, abi: any, fullyQualifiedName: string) => boolean` used to filter elements from each exported ABI | `() => true` |
 
+ Note that the configuration formatted as either a single `Object`, or an `Array` of objects.  An `Array` may be used to specify multiple outputs.
+
 ```javascript
 abiExporter: {
   path: './data/abi',
@@ -42,6 +44,19 @@ abiExporter: {
   spacing: 2,
   pretty: true,
 }
+
+// or
+
+abiExporter: [
+  {
+    path: './abi/pretty',
+    pretty: true,
+  },
+  {
+    path: './abi/ugly',
+    pretty: false,
+  },
+]
 ```
 
 The included Hardhat tasks may be run manually:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,18 +1,20 @@
 import 'hardhat/types/config';
 
+interface AbiExporterUserConfig {
+  path?: string,
+  runOnCompile?: boolean,
+  clear?: boolean,
+  flat?: boolean,
+  only?: string[],
+  except?: string[],
+  spacing?: number,
+  pretty?: boolean,
+  filter?: (abiElement: any, index: number, abi: any, fullyQualifiedName: string) => boolean,
+}
+
 declare module 'hardhat/types/config' {
   interface HardhatUserConfig {
-    abiExporter?: {
-      path?: string,
-      runOnCompile?: boolean,
-      clear?: boolean,
-      flat?: boolean,
-      only?: string[],
-      except?: string[],
-      spacing?: number,
-      pretty?: boolean,
-      filter?: (abiElement: any, index: number, abi: any, fullyQualifiedName: string) => boolean,
-    }
+    abiExporter?: AbiExporterUserConfig | AbiExporterUserConfig[]
   }
 
   interface HardhatConfig {
@@ -26,6 +28,6 @@ declare module 'hardhat/types/config' {
       spacing: number,
       pretty: boolean,
       filter: (abiElement: any, index: number, abi: any, fullyQualifiedName: string) => boolean,
-    }
+    }[]
   }
 }

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ require('./tasks/clear_abi.js');
 require('./tasks/export_abi.js');
 require('./tasks/compile.js');
 
-extendConfig(function (config, userConfig) {
-  config.abiExporter = Object.assign(
+function withDefaults(abiExporterConfig) {
+  return Object.assign(
     {
       path: './abi',
       runOnCompile: false,
@@ -17,6 +17,15 @@ extendConfig(function (config, userConfig) {
       pretty: false,
       filter: () => true,
     },
-    userConfig.abiExporter
+    abiExporterConfig
   );
+}
+
+extendConfig(function (config, userConfig) {
+  let abiExporterConfig = userConfig.abiExporter;
+  if (!Array.isArray(abiExporterConfig)) {
+    abiExporterConfig = [abiExporterConfig];
+  }
+
+  config.abiExporter = abiExporterConfig.map(withDefaults);
 });

--- a/index.js
+++ b/index.js
@@ -4,28 +4,20 @@ require('./tasks/clear_abi.js');
 require('./tasks/export_abi.js');
 require('./tasks/compile.js');
 
-function withDefaults(abiExporterConfig) {
-  return Object.assign(
-    {
-      path: './abi',
-      runOnCompile: false,
-      clear: false,
-      flat: false,
-      only: [],
-      except: [],
-      spacing: 2,
-      pretty: false,
-      filter: () => true,
-    },
-    abiExporterConfig
-  );
-}
+const DEFAULT_CONFIG = {
+  path: './abi',
+  runOnCompile: false,
+  clear: false,
+  flat: false,
+  only: [],
+  except: [],
+  spacing: 2,
+  pretty: false,
+  filter: () => true,
+};
 
 extendConfig(function (config, userConfig) {
-  let abiExporterConfig = userConfig.abiExporter;
-  if (!Array.isArray(abiExporterConfig)) {
-    abiExporterConfig = [abiExporterConfig];
-  }
-
-  config.abiExporter = abiExporterConfig.map(withDefaults);
+  config.abiExporter = [userConfig.abiExporter].flatten().map(function (el) {
+    return Object.assign(DEFAULT_CONFIG, el);
+  });
 });

--- a/tasks/clear_abi.js
+++ b/tasks/clear_abi.js
@@ -20,6 +20,10 @@ const readdirRecursive = function(dirPath, output = []) {
 };
 
 task('clear-abi', async function (args, hre) {
+  await hre.run('clear-abi-group');
+});
+
+subtask('clear-abi-group', async function (args, hre) {
   const config = hre.config.abiExporter;
 
   const outputDirectory = path.resolve(hre.config.paths.root, config.path);

--- a/tasks/clear_abi.js
+++ b/tasks/clear_abi.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const deleteEmpty = require('delete-empty');
+const { types } = require('hardhat/config');
 const { Interface } = require('@ethersproject/abi');
 
 const readdirRecursive = function(dirPath, output = []) {
@@ -20,15 +21,17 @@ const readdirRecursive = function(dirPath, output = []) {
 };
 
 task('clear-abi', async function (args, hre) {
-  const config = hre.config.abiExporter;
+  const configs = hre.config.abiExporter;
 
-  await hre.run('clear-abi-group', { path: config.path });
+  await Promise.all(configs.map((abiExporterConfig) => {
+    return hre.run('clear-abi-group', { path: abiExporterConfig.path });
+  }));
 });
 
 subtask(
   'clear-abi-group'
 ).addParam(
-  'path'
+  'path', 'path to look for ABIs', undefined, types.string
 ).setAction(async function (args, hre) {
   const outputDirectory = path.resolve(hre.config.paths.root, args.path);
 

--- a/tasks/clear_abi.js
+++ b/tasks/clear_abi.js
@@ -20,13 +20,17 @@ const readdirRecursive = function(dirPath, output = []) {
 };
 
 task('clear-abi', async function (args, hre) {
-  await hre.run('clear-abi-group');
-});
-
-subtask('clear-abi-group', async function (args, hre) {
   const config = hre.config.abiExporter;
 
-  const outputDirectory = path.resolve(hre.config.paths.root, config.path);
+  await hre.run('clear-abi-group', { path: config.path });
+});
+
+subtask(
+  'clear-abi-group'
+).addParam(
+  'path'
+).setAction(async function (args, hre) {
+  const outputDirectory = path.resolve(hre.config.paths.root, args.path);
 
   if (!fs.existsSync(outputDirectory)) {
     return;

--- a/tasks/compile.js
+++ b/tasks/compile.js
@@ -7,8 +7,13 @@ task(TASK_COMPILE).addFlag(
 ).setAction(async function (args, hre, runSuper) {
   await runSuper();
 
-  if (hre.config.abiExporter.runOnCompile && !args.noExportAbi) {
-    // Disable compile to avoid an infinite loop
-    await hre.run('export-abi', { noCompile: true });
+  if (!args.noExportAbi) {
+    const configs = hre.config.abiExporter;
+
+    await Promise.all(configs.map(abiGroupConfig => {
+      if (abiGroupConfig.runOnCompile) {
+        return hre.run('export-abi-group', { abiGroupConfig });
+      }
+    }));
   }
 });

--- a/tasks/export_abi.js
+++ b/tasks/export_abi.js
@@ -4,11 +4,17 @@ const { HardhatPluginError } = require('hardhat/plugins');
 const { Interface, FormatTypes } = require('@ethersproject/abi');
 
 task('export-abi', async function (args, hre) {
-  await hre.run('export-abi-group');
+  const config = hre.config.abiExporter;
+
+  await hre.run('export-abi-group', { abiGroupConfig: config });
 });
 
-subtask('export-abi-group', async function (args, hre) {
-  const config = hre.config.abiExporter;
+subtask(
+  'export-abi-group'
+).addParam(
+  'abiGroupConfig', undefined, undefined, Object
+).setAction(async function (args, hre) {
+  const { abiGroupConfig: config } = args;
 
   const outputDirectory = path.resolve(hre.config.paths.root, config.path);
 

--- a/tasks/export_abi.js
+++ b/tasks/export_abi.js
@@ -4,6 +4,10 @@ const { HardhatPluginError } = require('hardhat/plugins');
 const { Interface, FormatTypes } = require('@ethersproject/abi');
 
 task('export-abi', async function (args, hre) {
+  await hre.run('export-abi-group');
+});
+
+subtask('export-abi-group', async function (args, hre) {
   const config = hre.config.abiExporter;
 
   const outputDirectory = path.resolve(hre.config.paths.root, config.path);


### PR DESCRIPTION
Accept an array of configuration objects and run an export for each one separately.

Some initial outstanding issues:
* [ ] the `abiGroupConfig` object passed to the `export-abi-group` subtask is a temporary solution, and need to be type-checked and probably divided into multiple arguments
* [x] the flow optimization introduced in 66b81cc708dd7d3a480089823da2fdeeaeb11a9b will no longer work
* [x] the types in `index.d.ts` need to be fixed to enable passing an array, and the tasks need to execute a separate subtask call for each array element