### PR TITLE
compile contracts by default before exporting abi

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ yarn run hardhat export-abi
 yarn run hardhat clear-abi
 ```
 
+By default, the hardhat `compile` task is run before exporting ABIs.  This behavior can be disabled with the `--no-compile` flag:
+
+```bash
+yarn run hardhat export-abi --no-compile
+```
+
+
 The `path` directory will be created if it does not exist.
 
 The `clear` option is set to `false` by default because it represents a destructive action, but should be set to `true` in most cases.

--- a/tasks/compile.js
+++ b/tasks/compile.js
@@ -2,10 +2,13 @@ const {
   TASK_COMPILE,
 } = require('hardhat/builtin-tasks/task-names');
 
-task(TASK_COMPILE, async function (args, hre, runSuper) {
+task(TASK_COMPILE).addFlag(
+  'noExportAbi', 'Don\'t export ABI after running this task, even if runOnCompile option is enabled'
+).setAction(async function (args, hre, runSuper) {
   await runSuper();
 
-  if (hre.config.abiExporter.runOnCompile) {
-    await hre.run('export-abi');
+  if (hre.config.abiExporter.runOnCompile && !args.noExportAbi) {
+    // Disable compile to avoid an infinite loop
+    await hre.run('export-abi', { noCompile: true });
   }
 });

--- a/tasks/export_abi.js
+++ b/tasks/export_abi.js
@@ -7,7 +7,7 @@ task(
   'export-abi'
 ).addFlag(
   'noCompile', 'Don\'t compile before running this task'
-).setAction(async function sizeContracts(args, hre) {
+).setAction(async function (args, hre) {
   const config = hre.config.abiExporter;
 
   if (!args.noCompile) {

--- a/tasks/export_abi.js
+++ b/tasks/export_abi.js
@@ -2,17 +2,20 @@ const fs = require('fs');
 const path = require('path');
 const { HardhatPluginError } = require('hardhat/plugins');
 const { Interface, FormatTypes } = require('@ethersproject/abi');
+const {
+  TASK_COMPILE,
+} = require('hardhat/builtin-tasks/task-names');
 
 task(
   'export-abi'
 ).addFlag(
   'noCompile', 'Don\'t compile before running this task'
 ).setAction(async function (args, hre) {
-  const config = hre.config.abiExporter;
-
   if (!args.noCompile) {
-    await hre.run('compile', { noSizeContracts: true });
+    await hre.run(TASK_COMPILE, { noSizeContracts: true });
   }
+
+  const config = hre.config.abiExporter;
 
   const outputDirectory = path.resolve(hre.config.paths.root, config.path);
 

--- a/tasks/export_abi.js
+++ b/tasks/export_abi.js
@@ -3,8 +3,16 @@ const path = require('path');
 const { HardhatPluginError } = require('hardhat/plugins');
 const { Interface, FormatTypes } = require('@ethersproject/abi');
 
-task('export-abi', async function (args, hre) {
+task(
+  'export-abi'
+).addFlag(
+  'noCompile', 'Don\'t compile before running this task'
+).setAction(async function sizeContracts(args, hre) {
   const config = hre.config.abiExporter;
+
+  if (!args.noCompile) {
+    await hre.run('compile', { noSizeContracts: true });
+  }
 
   const outputDirectory = path.resolve(hre.config.paths.root, config.path);
 


### PR DESCRIPTION
Impose behavior similar to that of https://github.com/ItsNickBarry/hardhat-contract-sizer/pull/13.