### PR TITLE
feat: typescript format

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add configuration under the `abiExporter` key:
 | `except` | `Array` of `String` matchers used to exclude contracts | `[]` |
 | `spacing` | number of spaces per indentation level of formatted output | `2` |
 | `pretty` | whether to use interface-style formatting of output for better readability | `false` |
-| `format` | format type ("json", "minimal", "fullName"). Alternative to `pretty` | `json` |
+| `format` | format type ("json", "minimal", "fullName", "typescript"). Alternative to `pretty` | `json` |
 | `filter` | `Function` with signature `(abiElement: any, index: number, abi: any, fullyQualifiedName: string) => boolean` used to filter elements from each exported ABI | `() => true` |
 | `rename` | `Function` with signature `(sourceName: string, contractName: string) => string` used to rename an exported ABI (incompatible with `flat` option) | `undefined` |
 

--- a/tasks/clear_abi.js
+++ b/tasks/clear_abi.js
@@ -34,6 +34,7 @@ subtask(
   'path', 'path to look for ABIs', undefined, types.string
 ).setAction(async function (args, hre) {
   const outputDirectory = path.resolve(hre.config.paths.root, args.path);
+  const outputExtension = args.format === 'typescript' ? '.ts' : '.json';
 
   if (!fs.existsSync(outputDirectory)) {
     return;
@@ -42,7 +43,7 @@ subtask(
   const files = readdirRecursive(outputDirectory);
 
   await Promise.all(files.map(async function (file) {
-    if (path.extname(file) !== '.json') {
+    if (path.extname(file) !== outputExtension) {
       // ABIs must be stored as JSON
       return;
     }


### PR DESCRIPTION
## Description
Add `typescript` as a `format` option.

This allows importing the abi with the constant type in TypeScript, making the abi usable by [viem](https://viem.sh/).
Currently this is done either manually, using typechain or through bespoke generator scripts ([example](https://github.com/latticexyz/mud/pull/1403))

## Example ABI

```json
[
  {
    "inputs": [],
    "stateMutability": "nonpayable",
    "type": "constructor"
  }
]
```

becomes

```ts
export default [
  {
    "inputs": [],
    "stateMutability": "nonpayable",
    "type": "constructor"
  }
] as const;
```

## Example usage (viem)
```ts
import { encodeFunctionData } from 'viem';
import ERC20 from '../abi/ERC20'; // Your exported contract abi

// Fully typed thanks to viem and the const abi
encodeFunctonData({
  abi: ERC20,
  functionName: 'transfer',
  args: ['0x...', 100n],
});
```

