### PR TITLE
Update Hardhat commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,19 +95,19 @@ abiExporter: [
 The included Hardhat tasks may be run manually:
 
 ```bash
-npx hardhat export-abi
-npx hardhat clear-abi
+npx hardhat abi export
+npx hardhat abi clear
 # or
-pnpm hardhat export-abi
-pnpm hardhat clear-abi
+pnpm hardhat abi export
+pnpm hardhat abi clear
 ```
 
 By default, the hardhat `compile` task is run before exporting ABIs. This behavior can be disabled with the `--no-compile` flag:
 
 ```bash
-npx hardhat export-abi --no-compile
+npx hardhat abi export --no-compile
 # or
-pnpm hardhat export-abi --no-compile
+pnpm hardhat abi export --no-compile
 ```
 
 The `path` directory will be created if it does not exist.


### PR DESCRIPTION
After migrating from hh@v2 to hh@v3 along with the abi-exporter plugin, I found that the old commands no longer work. It looks like the commands have been changed at https://github.com/solidstate-network/hardhat-abi-exporter/blob/master/src/task_names.ts

The proposed command updates in the documentation have been tested with npm.